### PR TITLE
Use template specialization instead of inheritence

### DIFF
--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -14,19 +14,16 @@
 
 from rosbag2_py._rosbag2_py import \
   ConverterOptions, \
-  Reader, \
   SequentialCompressionReader, \
   SequentialCompressionWriter, \
   SequentialReader, \
   SequentialWriter, \
   StorageFilter, \
   StorageOptions, \
-  TopicMetadata, \
-  Writer
+  TopicMetadata
 
 __all__ = [
     'ConverterOptions',
-    'Reader',
     'SequentialCompressionReader',
     'SequentialCompressionWriter',
     'SequentialReader',
@@ -34,5 +31,4 @@ __all__ = [
     'StorageFilter',
     'StorageOptions',
     'TopicMetadata',
-    'Writer'
 ]

--- a/rosbag2_py/src/rosbag2_py/_rosbag2_py.cpp
+++ b/rosbag2_py/src/rosbag2_py/_rosbag2_py.cpp
@@ -44,7 +44,6 @@ public:
   Reader()
   {
     reader_ = std::make_unique<rosbag2_cpp::Reader>(std::make_unique<T>());
-    initialized_ = true;
   }
 
   void open(
@@ -89,7 +88,6 @@ public:
 
 protected:
   std::unique_ptr<rosbag2_cpp::Reader> reader_;
-  bool initialized_;
 };
 
 template<typename T>
@@ -99,7 +97,6 @@ public:
   Writer()
   {
     writer_ = std::make_unique<rosbag2_cpp::Writer>(std::make_unique<T>());
-    initialized_ = true;
   }
 
   void open(
@@ -137,7 +134,6 @@ public:
 
 protected:
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
-  bool initialized_;
 };
 
 }  // namespace rosbag2_py

--- a/rosbag2_py/src/rosbag2_py/_rosbag2_py.cpp
+++ b/rosbag2_py/src/rosbag2_py/_rosbag2_py.cpp
@@ -42,8 +42,8 @@ class Reader
 {
 public:
   Reader()
+  : reader_(std::make_unique<rosbag2_cpp::Reader>(std::make_unique<T>()))
   {
-    reader_ = std::make_unique<rosbag2_cpp::Reader>(std::make_unique<T>());
   }
 
   void open(
@@ -95,8 +95,8 @@ class Writer
 {
 public:
   Writer()
+  : writer_(std::make_unique<rosbag2_cpp::Writer>(std::make_unique<T>()))
   {
-    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::make_unique<T>());
   }
 
   void open(

--- a/rosbag2_py/src/rosbag2_py/_rosbag2_py.cpp
+++ b/rosbag2_py/src/rosbag2_py/_rosbag2_py.cpp
@@ -43,8 +43,7 @@ class Reader
 public:
   Reader()
   {
-    auto reader = std::make_unique<T>();
-    reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(reader));
+    reader_ = std::make_unique<rosbag2_cpp::Reader>(std::make_unique<T>());
     initialized_ = true;
   }
 
@@ -99,8 +98,7 @@ class Writer
 public:
   Writer()
   {
-    auto writer = std::make_unique<T>();
-    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(writer));
+    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::make_unique<T>());
     initialized_ = true;
   }
 


### PR DESCRIPTION
This makes the implementation slightly more compact. And adding a new specialization should be more straight forward as we only have to modify the cpp file in one place.

I don't know if this actually makes it more readable :man_shrugging: 